### PR TITLE
feat: 그룹데이터 api연결 및 티어 변경사항 fix

### DIFF
--- a/src/assets/icons/group/bronze.svg
+++ b/src/assets/icons/group/bronze.svg
@@ -1,0 +1,44 @@
+<svg width="76" height="77" viewBox="0 0 76 77" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di_2611_2349)">
+<rect x="4" y="0.692871" width="68" height="68" rx="34" fill="url(#paint0_linear_2611_2349)" shape-rendering="crispEdges"/>
+<g filter="url(#filter1_i_2611_2349)">
+<path d="M31.4653 58.089C30.2191 57.9906 29.0204 57.3681 28.2179 56.2777C26.7464 54.2816 27.1569 51.4704 29.1343 49.9968L43.0634 39.6188C43.1425 39.5581 43.1761 39.5265 43.132 39.3829C43.0898 39.236 43.0549 39.2312 42.943 39.2216L33.2315 38.549C33.2084 38.5467 33.1887 38.5463 33.1657 38.544C29.3409 38.2409 26.1684 35.6522 25.0792 31.9431C23.9865 28.2208 25.2639 24.3127 28.3398 21.9882C28.3469 21.9834 28.3559 21.9753 28.3657 21.9699L41.5342 12.1546C43.5117 10.681 46.306 11.1048 47.7801 13.1003C49.2515 15.0964 48.8411 17.9076 46.8643 19.3839L33.7101 29.1897C33.6284 29.2511 33.5974 29.2821 33.6396 29.429C33.6818 29.5759 33.7326 29.5877 33.8286 29.5903L43.5401 30.2629C43.5606 30.2659 43.5829 30.2655 43.6059 30.2678C47.4307 30.571 50.6032 33.1596 51.6924 36.8687C52.7851 40.5911 51.505 44.4999 48.4319 46.8237C48.4247 46.8284 48.4157 46.8365 48.4085 46.8413L34.4658 57.2314C33.5678 57.8986 32.5042 58.178 31.47 58.0962L31.4653 58.089Z" fill="url(#paint1_linear_2611_2349)"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_di_2611_2349" x="0" y="0.692871" width="76" height="76" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.3 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2611_2349"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2611_2349" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.92 0 0 0 0 1 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_2611_2349"/>
+</filter>
+<filter id="filter1_i_2611_2349" x="24.6941" y="10.2761" width="27.3831" height="47.834" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feGaussianBlur stdDeviation="3.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.961068 0 0 0 0 0.961068 0 0 0 0 0.961068 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_2611_2349"/>
+</filter>
+<linearGradient id="paint0_linear_2611_2349" x1="4" y1="34.6929" x2="72" y2="34.6929" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF6330"/>
+<stop offset="1" stop-color="#FF3F00"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2611_2349" x1="23.1747" y1="38.6652" x2="52.8253" y2="30.7204" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF6330"/>
+<stop offset="1" stop-color="#FF3F00"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/assets/icons/group/gold.svg
+++ b/src/assets/icons/group/gold.svg
@@ -1,0 +1,44 @@
+<svg width="76" height="77" viewBox="0 0 76 77" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di_2611_2351)">
+<rect x="4" y="0.370605" width="68" height="68" rx="34" fill="url(#paint0_linear_2611_2351)" shape-rendering="crispEdges"/>
+<g filter="url(#filter1_i_2611_2351)">
+<path d="M31.4653 57.7668C30.2191 57.6684 29.0204 57.0458 28.2179 55.9555C26.7464 53.9593 27.1569 51.1481 29.1343 49.6745L43.0634 39.2966C43.1425 39.2358 43.1761 39.2042 43.132 39.0606C43.0898 38.9137 43.0549 38.9089 42.943 38.8994L33.2315 38.2267C33.2084 38.2244 33.1887 38.2241 33.1657 38.2218C29.3409 37.9186 26.1684 35.33 25.0792 31.6209C23.9865 27.8986 25.2639 23.9904 28.3398 21.6659C28.3469 21.6612 28.3559 21.6531 28.3657 21.6476L41.5342 11.8323C43.5117 10.3587 46.306 10.7826 47.7801 12.778C49.2515 14.7742 48.8411 17.5854 46.8643 19.0616L33.7101 28.8674C33.6284 28.9289 33.5974 28.9598 33.6396 29.1067C33.6818 29.2536 33.7326 29.2655 33.8286 29.268L43.5401 29.9406C43.5606 29.9436 43.5829 29.9433 43.6059 29.9456C47.4307 30.2487 50.6032 32.8374 51.6924 36.5465C52.7851 40.2688 51.505 44.1776 48.4319 46.5014C48.4247 46.5062 48.4157 46.5143 48.4085 46.519L34.4658 56.9091C33.5678 57.5764 32.5042 57.8557 31.47 57.774L31.4653 57.7668Z" fill="url(#paint1_linear_2611_2351)"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_di_2611_2351" x="0" y="0.370605" width="76" height="76" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.54 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2611_2351"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2611_2351" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.92 0 0 0 0 1 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_2611_2351"/>
+</filter>
+<filter id="filter1_i_2611_2351" x="24.6941" y="9.95386" width="27.3831" height="47.834" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feGaussianBlur stdDeviation="3.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.961068 0 0 0 0 0.961068 0 0 0 0 0.961068 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_2611_2351"/>
+</filter>
+<linearGradient id="paint0_linear_2611_2351" x1="72" y1="34.3706" x2="4" y2="34.3706" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFD362"/>
+<stop offset="1" stop-color="#FFA51E"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2611_2351" x1="52.8253" y1="30.3981" x2="23.1747" y2="38.343" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFD362"/>
+<stop offset="1" stop-color="#FFA51E"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/assets/icons/group/silver.svg
+++ b/src/assets/icons/group/silver.svg
@@ -1,0 +1,44 @@
+<svg width="76" height="77" viewBox="0 0 76 77" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di_2611_2347)">
+<rect x="4" y="0.0317383" width="68" height="68" rx="34" fill="url(#paint0_linear_2611_2347)" shape-rendering="crispEdges"/>
+<g filter="url(#filter1_i_2611_2347)">
+<path d="M31.4653 57.4279C30.2191 57.3295 29.0204 56.707 28.2179 55.6166C26.7464 53.6205 27.1569 50.8093 29.1343 49.3357L43.0634 38.9577C43.1425 38.8969 43.1761 38.8653 43.132 38.7217C43.0898 38.5748 43.0549 38.5701 42.943 38.5605L33.2315 37.8879C33.2084 37.8856 33.1887 37.8852 33.1657 37.8829C29.3409 37.5797 26.1684 34.9911 25.0792 31.282C23.9865 27.5597 25.2639 23.6516 28.3398 21.327C28.3469 21.3223 28.3559 21.3142 28.3657 21.3088L41.5342 11.4934C43.5117 10.0199 46.306 10.4437 47.7801 12.4392C49.2515 14.4353 48.8411 17.2465 46.8643 18.7227L33.7101 28.5286C33.6284 28.59 33.5974 28.6209 33.6396 28.7679C33.6818 28.9148 33.7326 28.9266 33.8286 28.9291L43.5401 29.6017C43.5606 29.6047 43.5829 29.6044 43.6059 29.6067C47.4307 29.9099 50.6032 32.4985 51.6924 36.2076C52.7851 39.9299 51.505 43.8388 48.4319 46.1626C48.4247 46.1673 48.4157 46.1754 48.4085 46.1801L34.4658 56.5702C33.5678 57.2375 32.5042 57.5168 31.47 57.4351L31.4653 57.4279Z" fill="url(#paint1_linear_2611_2347)"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_di_2611_2347" x="0" y="0.0317383" width="76" height="76" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.46 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2611_2347"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2611_2347" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.901567 0 0 0 0 0.740967 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_2611_2347"/>
+</filter>
+<filter id="filter1_i_2611_2347" x="24.6941" y="9.61499" width="27.3831" height="47.834" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feGaussianBlur stdDeviation="3.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.961068 0 0 0 0 0.961068 0 0 0 0 0.961068 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_2611_2347"/>
+</filter>
+<linearGradient id="paint0_linear_2611_2347" x1="72" y1="34.0317" x2="4" y2="34.0317" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1E58EC"/>
+<stop offset="1" stop-color="#525E9D"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2611_2347" x1="52.8253" y1="30.0592" x2="23.1747" y2="38.0041" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1E58EC"/>
+<stop offset="1" stop-color="#525E9D"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/pages/group/Group.jsx
+++ b/src/pages/group/Group.jsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useContext, useEffect, createContext, useState } from "react";
 import styled from "styled-components";
 import { Outlet } from "react-router-dom";
 import GroupHeader from "./group_components/GroupHeader";
 import GroupTabBar from "./group_components/GroupTabBar";
+import { getUserClubs, getUserInfo } from "../../apis/api/user";
 
 const FixedContainer = styled.div`
   top: 0;
@@ -18,17 +19,64 @@ const ContentContainer = styled.div`
   flex-direction: column;
   flex-grow: 1;
 `;
+export const GroupContext = createContext();
 
 const Group = () => {
+  const [userInfo, setUserInfo] = useState(null);
+  const [userClubs, setUserClubs] = useState([]);
+  const [chooseClubId, setChooseClubId] = useState(0);
+  const [groupData, setGroupData] = useState([]); //유저가 속한 동아리 데이터
+  const [Loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchGroup = async () => {
+      try {
+        const accessToken = localStorage.getItem("accessToken");
+        const fetchUserInfo = await getUserInfo(accessToken);
+        console.log("User Info:", fetchUserInfo);
+        setUserInfo(fetchUserInfo);
+
+        const fetchUserClubs = await getUserClubs(accessToken);
+        console.log("User Clubs:", fetchUserClubs);
+        setUserClubs(fetchUserClubs);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchGroup();
+  }, []);
+  useEffect(() => {
+    setLoading(false);
+    if (userClubs && userClubs.memberClubResponseList) {
+      setGroupData(userClubs.memberClubResponseList);
+      setLoading(true);
+      console.log("userClubsuserClubs", userClubs.memberClubResponseList);
+      console.log(
+        "userClubsuserClubsuserClubsuserClubsuserClubsuserClubs",
+        groupData.length
+      );
+    }
+  }, [userClubs]);
   return (
     <>
-      <FixedContainer>
-        <GroupHeader />
-        <GroupTabBar />
-      </FixedContainer>
-      <ContentContainer>
-        <Outlet />
-      </ContentContainer>
+      <GroupContext.Provider
+        value={{
+          groupData,
+          Loading,
+          userInfo,
+          userClubs,
+          chooseClubId,
+          setChooseClubId,
+        }}
+      >
+        <FixedContainer>
+          <GroupHeader />
+          <GroupTabBar />
+        </FixedContainer>
+        <ContentContainer>
+          <Outlet context={{ userInfo, userClubs }} />
+        </ContentContainer>
+      </GroupContext.Provider>
     </>
   );
 };

--- a/src/pages/group/basicinfo/BasicInfo.jsx
+++ b/src/pages/group/basicinfo/BasicInfo.jsx
@@ -1,11 +1,14 @@
 import styled from "styled-components";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import ClubMainInfo from "./basicInfo_components/ClubMainInfo";
 import ClubSubInfo from "./basicInfo_components/ClubSubInfo";
 import Rank from "./Rank";
 import axios from "axios";
+import { GroupContext } from "../Group";
 
 const BasicInfo = () => {
+  const { chooseClubId, groupData, Loading } = useContext(GroupContext);
+
   const [information, setInfomation] = useState({
     id: 1,
     clubMessage: "",
@@ -22,7 +25,9 @@ const BasicInfo = () => {
   });
   const getInfo = async () => {
     axios
-      .get(`${process.env.REACT_APP_SERVER_URL}/v1/api/clubs/1`)
+      .get(
+        `${process.env.REACT_APP_SERVER_URL}/v1/api/clubs/${groupData[chooseClubId].clubId}`
+      )
       .then((res) => {
         console.log(res.data);
         setInfomation(res.data);
@@ -33,8 +38,11 @@ const BasicInfo = () => {
   };
 
   useEffect(() => {
-    getInfo();
-  }, []);
+    console.log(groupData);
+    if (groupData && chooseClubId !== undefined && groupData.length > 0) {
+      getInfo();
+    }
+  }, [chooseClubId, groupData, Loading]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const closeModal = () => {
     setIsModalOpen(false);
@@ -52,20 +60,28 @@ const BasicInfo = () => {
   };
   return (
     <>
-      <BaseContainer>
-        <ClubMainInfo
-          region={information.tags[0]}
-          personality={information.tags[1]}
-          name={information.clubName}
-          memRecent={information.numberOfMembers}
-          memMax={information.maxMembers}
-          establishDate={fommatDate()}
-          img={information.logo}
-        />
-        <ClubSubInfo onClick={toggleModal} information={information} />
-      </BaseContainer>
+      {Loading && groupData && (
+        <>
+          <BaseContainer>
+            <ClubMainInfo
+              region={information.tags[0]}
+              personality={information.tags[1]}
+              name={information.clubName}
+              memRecent={information.numberOfMembers}
+              memMax={information.maxMembers}
+              establishDate={fommatDate()}
+              img={information.logo}
+            />
+            <ClubSubInfo onClick={toggleModal} information={information} />
+          </BaseContainer>
 
-      <Rank isOpen={isModalOpen} onClose={closeModal} />
+          <Rank
+            isOpen={isModalOpen}
+            onClose={closeModal}
+            clubTier={information.clubTier}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/pages/group/basicinfo/ModiComponent/MaxPeople.jsx
+++ b/src/pages/group/basicinfo/ModiComponent/MaxPeople.jsx
@@ -1,14 +1,14 @@
-import styled from 'styled-components';
-import React from 'react';
-import { Wrapper, WrapperTitle } from './WrapperStyled';
-import { ReactComponent as UpIcon } from '../../../../assets/group/UpIcon.svg';
-import { ReactComponent as DownIcon } from '../../../../assets/group/DownIcon.svg';
-const MaxPeople = () => {
+import styled from "styled-components";
+import React from "react";
+import { Wrapper, WrapperTitle } from "./WrapperStyled";
+import { ReactComponent as UpIcon } from "../../../../assets/group/UpIcon.svg";
+import { ReactComponent as DownIcon } from "../../../../assets/group/DownIcon.svg";
+const MaxPeople = ({ count }) => {
   return (
     <Wrapper>
       <WrapperTitle>최대 인원 수</WrapperTitle>
       <MaxPeopleContent>
-        <Input type="number" />
+        <Input type="number" value={count} />
         <Regulate>
           <UpIcon />
           <DownIcon />

--- a/src/pages/group/basicinfo/Rank.jsx
+++ b/src/pages/group/basicinfo/Rank.jsx
@@ -1,10 +1,10 @@
-import styled from 'styled-components';
-import RankItem from './basicInfo_components/RankItem';
-import RankTab from './basicInfo_components/RankTab';
-import { useState } from 'react';
-import { ReactComponent as RankBackIcon1 } from '../../../assets/group/RankBackIcon1.svg';
-import { ReactComponent as RankBackIcon2 } from '../../../assets/group/RankBackIcon2.svg';
-import Awarding from './basicInfo_components/Awarding';
+import styled from "styled-components";
+import RankItem from "./basicInfo_components/RankItem";
+import RankTab from "./basicInfo_components/RankTab";
+import { useState } from "react";
+import { ReactComponent as RankBackIcon1 } from "../../../assets/group/RankBackIcon1.svg";
+import { ReactComponent as RankBackIcon2 } from "../../../assets/group/RankBackIcon2.svg";
+import Awarding from "./basicInfo_components/Awarding";
 const BaseContainer = styled.div`
   max-width: 649px;
   position: fixed;
@@ -18,7 +18,14 @@ const BaseContainer = styled.div`
   border-radius: 16px 16px 0px 0px;
   box-shadow: 0px -2px 87px 0px #475467;
   box-sizing: border-box;
-  background: linear-gradient(270deg, #1e58ec 0%, #525e9d 100%);
+  background: ${({ $clubTier }) => {
+    if ($clubTier === "BRONZE")
+      return "linear-gradient(90deg, #FF6330 0%, #FF3F00 100%)";
+    if ($clubTier === "SILVER")
+      return "linear-gradient(270deg, #1E58EC 0%, #52559D 100%)";
+    if ($clubTier === "GOLD")
+      return "linear-gradient(270deg, #FFD362 0%, #FFA51E 100%)";
+  }};
 `;
 const Header = styled.div`
   width: 100%;
@@ -85,35 +92,35 @@ const mockDataMonthly = [
     rank: 1,
     isUp: true,
     upDown: 2,
-    name: '중앙가르드',
+    name: "중앙가르드",
     score: 238,
   },
   {
     rank: 2,
     isUp: false,
     upDown: 1,
-    name: '중앙가르드',
+    name: "중앙가르드",
     score: 238,
   },
   {
     rank: 3,
     isUp: false,
     upDown: 2,
-    name: '중앙가르드',
+    name: "중앙가르드",
     score: 238,
   },
   {
     rank: 4,
     isUp: true,
     upDown: 1,
-    name: '중앙가르드',
+    name: "중앙가르드",
     score: 238,
   },
   {
     rank: 5,
     isUp: false,
     upDown: 1,
-    name: '중앙가르드',
+    name: "중앙가르드",
     score: 238,
   },
 ];
@@ -122,50 +129,54 @@ const mockDataAllTime = [
     rank: 1,
     isUp: true,
     upDown: 2,
-    name: '메롱',
+    name: "메롱",
     score: 238,
   },
   {
     rank: 2,
     isUp: false,
     upDown: 1,
-    name: '메롱',
+    name: "메롱",
     score: 238,
   },
   {
     rank: 3,
     isUp: false,
     upDown: 2,
-    name: '메롱',
+    name: "메롱",
     score: 238,
   },
   {
     rank: 4,
     isUp: true,
     upDown: 1,
-    name: '메롱',
+    name: "메롱",
     score: 238,
   },
   {
     rank: 5,
     isUp: false,
     upDown: 1,
-    name: '메롱',
+    name: "메롱",
     score: 238,
   },
 ];
-const Rank = ({ isOpen, onClose }) => {
-  const [activeTab, setActiveTab] = useState('monthly');
-  const listdata = activeTab === 'monthly' ? mockDataMonthly : mockDataAllTime;
+const Rank = ({ isOpen, onClose, clubTier }) => {
+  const [activeTab, setActiveTab] = useState("monthly");
+  const listdata = activeTab === "monthly" ? mockDataMonthly : mockDataAllTime;
   return (
     <>
       {isOpen && (
-        <BaseContainer>
+        <BaseContainer $clubTier={clubTier}>
           <Header>
             <BackButton onClick={onClose}> &lt; </BackButton>
             <TopText>티어</TopText>
           </Header>
-          <RankTab activeTab={activeTab} setActiveTab={setActiveTab} />
+          <RankTab
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            clubTier={clubTier}
+          />
           <Awarding />
           <ListContainer>
             {listdata.map((item) => (

--- a/src/pages/group/basicinfo/basicInfo_components/ClubSubInfo.jsx
+++ b/src/pages/group/basicinfo/basicInfo_components/ClubSubInfo.jsx
@@ -1,6 +1,8 @@
 import ClubComment from "./ClubComment";
 import styled from "styled-components";
-import { ReactComponent as Tier } from "../../../../assets/group/RankItem.svg";
+import { ReactComponent as BronzeIcon } from "../../../../assets/icons/group/bronze.svg";
+import { ReactComponent as SilverIcon } from "../../../../assets/icons/group/silver.svg";
+import { ReactComponent as GoldIcon } from "../../../../assets/icons/group/gold.svg";
 
 const Container = styled.div`
   display: flex;
@@ -17,7 +19,6 @@ const RankContainer = styled.div`
   padding: 12px;
   gap: 10px;
   width: 100%;
-  background: linear-gradient(270deg, #1e58ec 0%, #525e9d 100%);
   box-sizing: border-box;
 
   box-shadow: 0px 0px 8px rgba(110, 110, 110, 0.23);
@@ -41,7 +42,7 @@ const TextSmall = styled.div`
   font-weight: 400;
   line-height: 18px;
   letter-spacing: -0.011em;
-  color: #f9fafb;
+  color: #667085;
 `;
 
 const TextBIg = styled.div`
@@ -49,21 +50,34 @@ const TextBIg = styled.div`
   font-weight: 600;
   line-height: 19.2px;
   letter-spacing: -0.011em;
-  color: #ffffff;
+  color: #344054;
 `;
-
+const TextMid = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 19.2px;
+  letter-spacing: -0.011em;
+  color: #667085;
+`;
 const ClubSubInfo = ({ onClick, information }) => {
+  const tierTranslations = {
+    BRONZE: "브론즈",
+    SILVER: "실버",
+    GOLD: "골드",
+  };
+  const tierText = tierTranslations[information.clubTier];
   return (
     <Container>
       <RankContainer onClick={onClick}>
         <RankImg>
-          <Tier />
+          {tierText === "브론즈" && <BronzeIcon />}
+          {tierText === "실버" && <SilverIcon />}
+          {tierText === "골드" && <GoldIcon />}
         </RankImg>
 
         <RankTextContainer>
-          <TextSmall>티어 정보</TextSmall>
-          <TextBIg>{information.clubTier}</TextBIg>
-          <TextBIg>138팀 중 7위</TextBIg>
+          <TextBIg>{tierText}</TextBIg>
+          <TextMid>138팀 중 7위</TextMid>
           <TextSmall>다음 레벨까지 남은 순위 : 3위</TextSmall>
         </RankTextContainer>
       </RankContainer>

--- a/src/pages/group/basicinfo/basicInfo_components/RankTab.jsx
+++ b/src/pages/group/basicinfo/basicInfo_components/RankTab.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
+import React from "react";
+import styled from "styled-components";
 
 const Container = styled.div`
   display: flex;
@@ -24,29 +24,32 @@ const TabItem = styled.div`
   cursor: pointer;
 
   &::after {
-    content: '';
-    display: ${({ $active }) => ($active ? 'block' : 'none')};
+    content: "";
+    display: ${({ $active }) => ($active ? "block" : "none")};
     position: absolute;
     bottom: -5px;
     left: 0;
     height: 2px;
-    background: #ff6330;
+    background: ${({ $clubTier }) =>
+      $clubTier === "BRONZE" ? "#ffffff" : "#ff6330"};
     width: 100%;
   }
 `;
 
-const RankTab = ({ activeTab, setActiveTab }) => {
+const RankTab = ({ activeTab, setActiveTab, clubTier }) => {
   return (
     <Container>
       <TabItem
-        $active={activeTab === 'monthly'}
-        onClick={() => setActiveTab('monthly')}
+        $active={activeTab === "monthly"}
+        onClick={() => setActiveTab("monthly")}
+        $clubTier={clubTier}
       >
         Monthly
       </TabItem>
       <TabItem
-        $active={activeTab === 'all-time'}
-        onClick={() => setActiveTab('all-time')}
+        $active={activeTab === "all-time"}
+        onClick={() => setActiveTab("all-time")}
+        $clubTier={clubTier}
       >
         All time
       </TabItem>

--- a/src/pages/group/group_components/CreatePages.jsx
+++ b/src/pages/group/group_components/CreatePages.jsx
@@ -100,53 +100,7 @@ export const CreatePage3 = () => {
     </MainContainer>
   );
 };
-// export const CreatePage3 = () => {
-//   return (
-//     <MainContainer>
-//       <HeaderContainer>
-//         <HeaderStep>STEP 3</HeaderStep>
-//         <HeaderText>어떤 종목의 동아리인가요?</HeaderText>
-//       </HeaderContainer>
-//       <ContentContainer>
-//         <EventTitle>구기</EventTitle>
-//         <EventWrapper>
-//           <EventTag>축구</EventTag>
-//           <EventTag>농구</EventTag>
-//           <EventTag>배구</EventTag>
-//           <EventTag>야구</EventTag>
-//         </EventWrapper>
-//         <EventTitle>라켓</EventTitle>
-//         <EventWrapper>
-//           <EventTag>배드민턴</EventTag>
-//           <EventTag>테니스</EventTag>
-//           <EventTag>탁구</EventTag>
-//         </EventWrapper>
-//         <EventTitle>격투</EventTitle>
-//         <EventWrapper>
-//           <EventTag>태권도</EventTag>
-//           <EventTag>유도</EventTag>
-//           <EventTag>검도</EventTag>
-//         </EventWrapper>
-//         <EventTitle>육상</EventTitle>
-//         <EventWrapper>
-//           <EventTag>러닝</EventTag>
-//           <EventTag>크로스핏</EventTag>
-//           <EventTag>사이클</EventTag>
-//         </EventWrapper>
-//         <EventTitle>수상</EventTitle>
-//         <EventWrapper>
-//           <EventTag>수영</EventTag>
-//           <EventTag>서핑</EventTag>
-//           <EventTag>요트</EventTag>
-//         </EventWrapper>
-//       </ContentContainer>
-//       <ContentContainer>
-//         <InputTitle>직접 입력하기</InputTitle>
-//         <InputStyled />
-//       </ContentContainer>
-//     </MainContainer>
-//   );
-// };
+
 export const CreatePage4 = () => {
   return (
     <>
@@ -166,6 +120,26 @@ export const CreatePage4 = () => {
   );
 };
 export const CreatePage5 = () => {
+  return (
+    <>
+      <HeaderContainer>
+        <HeaderStep>STEP 5</HeaderStep>
+        <HeaderText>마지막이에요!</HeaderText>
+        <HeaderText>동아리 한마디와 </HeaderText>
+        <HeaderText>대표이미지를 설정해주세요.</HeaderText>
+      </HeaderContainer>
+      <ContentContainer>
+        <ContentTitle>동아리 한마디</ContentTitle>
+        <InputStyled />
+      </ContentContainer>
+      <ContentContainer>
+        <ContentTitle>대표 이미지 설정</ContentTitle>
+        <ImgWrapper />
+      </ContentContainer>
+    </>
+  );
+};
+export const CreatePage6 = () => {
   return (
     <>
       <HeaderContainer>
@@ -336,3 +310,5 @@ const EventTag = styled.div`
     background-color: #d3d3d3;
   }
 `;
+
+const CompleteContainer = styled.div``;

--- a/src/pages/group/group_components/GroupCreate.jsx
+++ b/src/pages/group/group_components/GroupCreate.jsx
@@ -19,6 +19,13 @@ const GroupCreate = ({ closeGroupCreate }) => {
   const BeforeStep = () => {
     setStep((prevStep) => prevStep - 1); // 다음 단계로 전환
   };
+
+  const [clubName, setClubName] = useState("");
+  const [clubCategory, setClubCategory] = useState("");
+  const [sportsCategory, setSportsCategory] = useState("");
+  const [maxMembers, setMaxMembers] = useState(0);
+  const [city, setCity] = useState("");
+  const [district, setDistrict] = useState("");
   // const accessToken = useAuthStore((state) => state.accessToken);
 
   // const handleSubmit = async () => {

--- a/src/pages/group/group_components/GroupHeader.jsx
+++ b/src/pages/group/group_components/GroupHeader.jsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import styled from "styled-components";
 import arrowdown_icon from "../../../assets/icons/group/arrow_down.svg";
 import run_emoji from "../../../assets/icons/group/run_emoji.svg";
@@ -7,6 +6,9 @@ import GroupSelectList from "./GroupSelectList";
 import { ReactComponent as ModiInfoIcon } from "../../../assets/group/ModiInfoIcon.svg";
 import { ReactComponent as AlarmIcon } from "../../../assets/group/AlarmIcon.svg";
 import ModifyInfo from "../basicinfo/ModifyInfo";
+
+import React, { useState, useEffect, useContext } from "react";
+import { GroupContext } from "../Group";
 
 function GroupHeader() {
   const [showGroupSelectList, setShowGroupSelectList] = useState(false);
@@ -17,17 +19,29 @@ function GroupHeader() {
   const closeModal = () => {
     setIsModalOpen(false);
   };
+
+  const { Loading, chooseClubId, groupData } = useContext(GroupContext);
+
+  useEffect(() => {
+    console.log(Loading);
+    console.log(groupData.length);
+    console.log(groupData[chooseClubId]);
+  }, []);
   return (
     <Container>
       <Wrapper>
         <RunEmoji />
-        <Title>중앙가르드</Title>
+        <Title>
+          {Loading && groupData && groupData[chooseClubId]
+            ? groupData[chooseClubId].clubName
+            : "Loading..."}
+        </Title>
         <ArrowDown
           onClick={(e) => {
             setShowGroupSelectList(!showGroupSelectList);
           }}
         />
-        {showGroupSelectList && <GroupSelectList />}
+        {showGroupSelectList && <GroupSelectList groupData={groupData} />}
       </Wrapper>
       <IconWrapper>
         <ModiInfoIcon onClick={toggleModal} />
@@ -40,7 +54,6 @@ function GroupHeader() {
 
 export default GroupHeader;
 
-
 const Container = styled.div`
   display: flex;
   justify-content: space-between;
@@ -51,7 +64,6 @@ const Container = styled.div`
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
-  background-color: pink;
   font-size: 16px;
   border-bottom: 1px solid #dcdcdc;
   position: relative;

--- a/src/pages/group/group_components/GroupSelectList.jsx
+++ b/src/pages/group/group_components/GroupSelectList.jsx
@@ -1,82 +1,70 @@
-import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
-import GroupCreate from './GroupCreate'
-import api from '../../../apis/utils/api';
+import React, { useContext, useState } from "react";
+import styled from "styled-components";
+import GroupCreate from "./GroupCreate";
+import api from "../../../apis/utils/api";
+import { GroupContext } from "../Group";
 
 const Container = styled.div`
   position: absolute;
   width: 100%;
   top: 40px;
   left: 80px;
-  padding: 12px 0px; 
-  background: white; 
-  box-shadow: 0px 2px 10px rgba(85, 91, 160, 0.43); 
-  border-radius: 8px; 
-  flex-direction: column; 
-  justify-content: center; 
-  align-items: center; 
-  gap: 12px; 
+  padding: 12px 0px;
+  background: white;
+  box-shadow: 0px 2px 10px rgba(85, 91, 160, 0.43);
+  border-radius: 8px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
   display: inline-flex;
   z-index: 1000;
 `;
 
 const GroupItem = styled.div`
-  color: #101828; 
-  font-size: 14px; 
-  line-height: 19px; 
+  color: #101828;
+  font-size: 14px;
+  line-height: 19px;
   word-wrap: break-word;
 `;
 
 const GroupCreateButton = styled.div`
-  color: #101828; 
-  font-size: 14px; 
-  line-height: 19px; 
+  color: #101828;
+  font-size: 14px;
+  line-height: 19px;
   word-wrap: break-word;
   border-top: 1px solid #dcdcdc;
   padding-top: 8px;
 `;
 
+function GroupSelectList({ groupData }) {
+  const { chooseClubId, setChooseClubId } = useContext(GroupContext);
 
-function GroupSelectList() {
-  const [groupData, setGroupData] = useState([]);
   const [showGroupCreate, setShowGroupCreate] = useState(false);
-
-  const accessToken = localStorage.getItem("accessToken");
-  // const groupData = [
-  //   { id: "1", name: "중앙가르드"},
-  //   { id: "2", name: "코테이토" },
-  //   { id: "3", name: "하하"}
-  // ];
-
-  useEffect(() => {
-    api.get('/v1/api/members/clubs', {
-      headers: {
-        'Content-Type': 'application/json',
-        access: `${accessToken}`,
-      }
-    })
-    .then(response => {
-      console.log(response)
-      setGroupData(response.data.memberClubResponseList);
-    })
-    .catch(error => {
-      console.error('동아리 데이터를 가져오는 중 오류가 발생했습니다:', error);
-    });
-  }, [accessToken]);
 
   return (
     <Container>
       {groupData.length > 0 ? (
-        groupData.map(group => (
-          <GroupItem key={group.clubId}>
-            {group.clubName}
-          </GroupItem>
-        ))
+        groupData.map((group, index) => {
+          //현재 동아리 제외
+          return (
+            <GroupItem
+              key={group.clubId}
+              onClick={() => setChooseClubId(index)}
+            >
+              {group.clubName}
+            </GroupItem>
+          );
+        })
       ) : (
         <p>가입된 동아리가 없습니다.</p>
       )}
-      <GroupCreateButton onClick={() => setShowGroupCreate(true)}>+ 동아리 생성</GroupCreateButton>
-      {showGroupCreate && <GroupCreate closeGroupCreate={() => setShowGroupCreate(false)} />}
+      <GroupCreateButton onClick={() => setShowGroupCreate(true)}>
+        + 동아리 생성
+      </GroupCreateButton>
+      {showGroupCreate && (
+        <GroupCreate closeGroupCreate={() => setShowGroupCreate(false)} />
+      )}
     </Container>
   );
 }

--- a/src/pages/group/schedule/Schedule.jsx
+++ b/src/pages/group/schedule/Schedule.jsx
@@ -4,13 +4,14 @@ import {
   GroupCalendar,
   StyledDot,
 } from "./schedule_components/Calendar";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useContext } from "react";
 import ScheduleItem, {
   AddSchedule,
   PlusIcon,
 } from "./schedule_components/ScheduleItem";
 import ScheduleAdd from "./ScheduleAdd";
 import axios from "axios";
+import { GroupContext } from "../Group";
 const BaseContainer = styled.div`
   width: 100%;
   height: 100%;
@@ -41,9 +42,13 @@ const ScheduleTitle = styled.div`
 
 const Schedule = () => {
   const [clubSchedule, setClubSchedule] = useState([]);
+  const { chooseClubId, groupData, Loading } = useContext(GroupContext);
+
   const getClubSchedule = async () => {
     axios
-      .get(`${process.env.REACT_APP_SERVER_URL}/v1/api/clubs/1/schedules`)
+      .get(
+        `${process.env.REACT_APP_SERVER_URL}/v1/api/clubs/${groupData[chooseClubId].clubId}/schedules`
+      )
       .then((res) => {
         console.log(res.data);
         setClubSchedule(res.data.schedules);
@@ -54,9 +59,11 @@ const Schedule = () => {
   };
 
   useEffect(() => {
-    getClubSchedule();
-  }, []);
-
+    console.log(groupData);
+    if (groupData && chooseClubId !== undefined && groupData.length > 0) {
+      getClubSchedule();
+    }
+  }, [chooseClubId, groupData, Loading]);
   const [date, setDate] = useState(new Date());
   const [selectedSchedule, setSelectedSchedule] = useState([]);
 

--- a/src/pages/group/schedule/ScheduleAdd.jsx
+++ b/src/pages/group/schedule/ScheduleAdd.jsx
@@ -1,16 +1,16 @@
-import styled from 'styled-components';
-import { ReactComponent as MemoIcon } from '../../../assets/icons/group/memo.svg';
-import { ReactComponent as LocationIcon } from '../../../assets/icons/group/location.svg';
-import { ReactComponent as LinkIcon } from '../../../assets/icons/group/link.svg';
-import { ReactComponent as ClockIcon } from '../../../assets/icons/group/clock.svg';
-import { ReactComponent as AlarmIcon } from '../../../assets/icons/group/alarm.svg';
+import styled from "styled-components";
+import { ReactComponent as MemoIcon } from "../../../assets/icons/group/memo.svg";
+import { ReactComponent as LocationIcon } from "../../../assets/icons/group/location.svg";
+import { ReactComponent as LinkIcon } from "../../../assets/icons/group/link.svg";
+import { ReactComponent as ClockIcon } from "../../../assets/icons/group/clock.svg";
+import { ReactComponent as AlarmIcon } from "../../../assets/icons/group/alarm.svg";
 
 import {
   ToggleSwitch,
   ToggleSlider,
   CheckBox,
-} from './schedule_components/ToggleButton';
-import { useState } from 'react';
+} from "./schedule_components/ToggleButton";
+import { useState } from "react";
 
 const BaseContainer = styled.div`
   max-width: 649px;
@@ -124,10 +124,10 @@ const ScheduleAdd = ({ isOpen, onClose }) => {
           <AddContainer>
             <AddTitle>
               <TiTlePoint />
-              <TiTleText placeholder={'제목'} />
+              <TiTleText placeholder={"제목"} />
             </AddTitle>
             <AddWrapper>
-              <LocationIcon /> <AddInput placeholder={'위치'} />
+              <LocationIcon /> <AddInput placeholder={"위치"} />
             </AddWrapper>
             <AddWrapper>
               <p>하루종일</p>
@@ -143,17 +143,16 @@ const ScheduleAdd = ({ isOpen, onClose }) => {
 
             <AddWrapper>
               <ClockIcon /> <AddInput type="datetime-local" />
-              >
               <AddInput type="datetime-local" />
             </AddWrapper>
             <AddWrapper>
               <AlarmIcon /> <p>알람</p>
             </AddWrapper>
             <AddWrapper>
-              <LinkIcon /> <AddInput placeholder={'URL'} />
+              <LinkIcon /> <AddInput placeholder={"URL"} />
             </AddWrapper>
             <AddWrapper>
-              <MemoIcon /> <AddInput placeholder={'메모'} />
+              <MemoIcon /> <AddInput placeholder={"메모"} />
             </AddWrapper>
           </AddContainer>
         </BaseContainer>


### PR DESCRIPTION
## Issue number
- #28 

## Summary

- 그룹헤더에서의 유저가 속한 동아리 리스트 api연결
- 그룹 전체 탭에서 해당 유저 정보 불러오기 및 유저가 속한 동아리 정보 불러오기 
- 위의 데이터를 context로 Group 하위 컴포넌트들에게 전해주게 구현
- 동아리 일정 api연결 
- 그룹헤더에서 동아리 선택시 동아리 정보 변경

## Describe your changes (option)

## Screenshot (option)
![image](https://github.com/user-attachments/assets/8c6cfa20-515c-4b19-a62a-511dcaa5858e)
![image](https://github.com/user-attachments/assets/b6e303ca-9fac-4224-bae3-23d4eb2b442f)
![image](https://github.com/user-attachments/assets/0cb9d6b4-281d-4697-8a58-db536b497801)
